### PR TITLE
gccd: fix repo name

### DIFF
--- a/git.fish
+++ b/git.fish
@@ -33,7 +33,7 @@ alias gcl 'git clone --recursive'
 
 function gccd -d 'Change directory to the repo after clone it'
   set -l repo $argv[1]
-  set -l name (echo $repo | sed "s#^.*/\(.*\)\(.git\)*#\1#")
+  set -l name (basename $repo .git)
   if [ (count $argv) -eq 2 ]
     set name $argv[2]
   end


### PR DESCRIPTION
The old command would fail if the url ended in `.git`.